### PR TITLE
fix: verify reset_token in cookie

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -264,7 +264,7 @@ class UserController extends Controller
                 return response()->json(['status' => 404, 'message' => 'User not found',], 404);
             }
 
-            $resetToken = urldecode($request->resetToken);
+            $resetToken = $request->cookie('reset_token');
 
             $decoded = base64_decode($resetToken);
 

--- a/app/Http/Requests/ResetPasswordRequest.php
+++ b/app/Http/Requests/ResetPasswordRequest.php
@@ -24,7 +24,6 @@ class ResetPasswordRequest extends FormRequest
         return [
             'email' => 'required|email',
             'newPassword' => 'required',
-            'resetToken' => 'required'
         ];
     }
 
@@ -41,7 +40,6 @@ class ResetPasswordRequest extends FormRequest
         return [
             'email' => 'Email',
             'newPassword' => 'New Password',
-            'resetToken' => 'Reset Token'
         ];
     }
 }

--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*'],
+    'allowed_origins' => ['http://localhost:3000', 'https://localhost:3000'],
 
     'allowed_origins_patterns' => [],
 
@@ -29,6 +29,6 @@ return [
 
     'max_age' => 0,
 
-    'supports_credentials' => false,
+    'supports_credentials' => true,
 
 ];


### PR DESCRIPTION
BE will verify reset_token in cookie.
FE doesn't need to send reset token in the body of request.